### PR TITLE
Some graphics fixes and something unrelated

### DIFF
--- a/hw/arm/t8030.c
+++ b/hw/arm/t8030.c
@@ -105,7 +105,7 @@
 #define T8030_SIO_DATA_SIZE     (0xf8000)
 #define T8030_SIO_DATA_REMAP    (0x220000)
 
-#define T8030_PANIC_BASE        (0x8ffeb0000)
+#define T8030_PANIC_BASE        (0x8fc2b4000)
 #define T8030_PANIC_SIZE        (0x100000)
 
 #define NOP_INST 0xd503201f

--- a/hw/arm/t8030.c
+++ b/hw/arm/t8030.c
@@ -1738,6 +1738,9 @@ static void t8030_machine_init(MachineState *machine)
     assert(set_dtb_prop(child, "oled-display", sizeof(data), &data));
     assert(set_dtb_prop(child, "graphics-featureset-class", 7, "MTL1,2"));
     assert(set_dtb_prop(child, "graphics-featureset-fallbacks", 15, "MTL1,2:GLES2,0"));
+    assert(set_dtb_prop(tms->device_tree, "target-type", 4, "sim")); // TODO: implement PMP
+    data = 1;
+    assert(set_dtb_prop(child, "device-color-policy", sizeof(data), &data));
 
     t8030_cpu_setup(machine);
 

--- a/hw/display/apple_h12p.c
+++ b/hw/display/apple_h12p.c
@@ -245,8 +245,8 @@ static const VMStateDescription vmstate_apple_h12p = {
 };
 
 static Property apple_h12p_props[] = {
-    DEFINE_PROP_UINT32("width", AppleH12PState, width, 828),
-    DEFINE_PROP_UINT32("height", AppleH12PState, height, 1792),
+    DEFINE_PROP_UINT32("width", AppleH12PState, width, 640),
+    DEFINE_PROP_UINT32("height", AppleH12PState, height, 960),
     DEFINE_PROP_END_OF_LIST()
 };
 

--- a/hw/display/apple_h12p.c
+++ b/hw/display/apple_h12p.c
@@ -124,6 +124,8 @@ void apple_h12p_create(MachineState *machine)
     assert(set_dtb_prop(child, "display-timing-info", sizeof(dispTimingInfo), &dispTimingInfo));
     uint32_t data = 0xD;
     assert(set_dtb_prop(child, "bics-param-set", sizeof(data), &data));
+    uint32_t dot_pitch = 326;
+    assert(set_dtb_prop(child, "dot-pitch", sizeof(dot_pitch), &dot_pitch));
     assert(set_dtb_prop(child, "function-brightness_update", 0, ""));
 
     DTBProp *prop = find_dtb_prop(child, "reg");
@@ -243,8 +245,8 @@ static const VMStateDescription vmstate_apple_h12p = {
 };
 
 static Property apple_h12p_props[] = {
-    DEFINE_PROP_UINT32("width", AppleH12PState, width, 480),
-    DEFINE_PROP_UINT32("height", AppleH12PState, height, 680),
+    DEFINE_PROP_UINT32("width", AppleH12PState, width, 828),
+    DEFINE_PROP_UINT32("height", AppleH12PState, height, 1792),
     DEFINE_PROP_END_OF_LIST()
 };
 

--- a/include/hw/display/apple_h12p.h
+++ b/include/hw/display/apple_h12p.h
@@ -16,7 +16,7 @@
 #include "qemu/timer.h"
 
 #define T8030_DISPLAY_BASE (0x8F7FB4000)
-#define T8030_DISPLAY_SIZE (35 * 1024 * 1024)
+#define T8030_DISPLAY_SIZE (67 * 1024 * 1024)
 
 #define TYPE_APPLE_H12P "apple-h12p"
 OBJECT_DECLARE_SIMPLE_TYPE(AppleH12PState, APPLE_H12P);

--- a/include/hw/display/apple_h12p.h
+++ b/include/hw/display/apple_h12p.h
@@ -48,7 +48,7 @@ struct AppleH12PState {
     AddressSpace dma_as;
     MemoryRegionSection vram_section;
     qemu_irq irqs[9];
-    uint32_t uppipe_int_filter, genpipe0_plane_start, genpipe0_plane_end;
+    uint32_t uppipe_int_filter, genpipe0_plane_start, genpipe0_plane_end, genpipe1_plane_start, genpipe1_plane_end;
     bool frame_processed;
     uint8_t regs[0x200000];
     QemuConsole *console;

--- a/target/arm/helper.c
+++ b/target/arm/helper.c
@@ -11093,7 +11093,7 @@ static CPUARMTBFlags rebuild_hflags_a64(CPUARMState *env, int el, int fp_el,
          * The decision of which action to take is left to a helper.
          */
         if (sctlr & (SCTLR_EnIA | SCTLR_EnIB | SCTLR_EnDA | SCTLR_EnDB)) {
-            DP_TBFLAG_A64(flags, PAUTH_ACTIVE, 1);
+            //DP_TBFLAG_A64(flags, PAUTH_ACTIVE, 1);
         }
     }
 

--- a/target/arm/ptw.c
+++ b/target/arm/ptw.c
@@ -438,6 +438,7 @@ static inline int
 pte_to_sprr_prot_is_guarded(CPUARMState *env, int ap, int xn, int pxn, bool guarded)
 {
     int sprr_idx = ((ap << 2) | (xn << 1) | pxn) & 0xf;
+    assert(arm_current_el(env) < 2);
     uint64_t sprr_perm = env->sprr.sprr_el_br_el1[arm_current_el(env)][arm_current_el(env)];
 
     if (arm_is_sprr_enabled(env)) {


### PR DESCRIPTION
Set dot-pitch and resolution [2] correctly, or else libMobileGestalt will complain.
Had to change pram address and vram size to iPhone 11 Pro [1] to avoid some issues. Should be good enough.
Also, put an assert somewhere, just to be safe. Noticed in a commit from the original author, that something doesn't add up.

At least for the ram dump in the recovery mode, a pitch of 900 is needed to show the apple logo correctly.
Not changed yet, as "someone" needs to figure out first, why the alpha gets mapped successfully, but the Apple logo won't.
The alpha channel is already there when/before DART gets mapped, but something is missing between having the surface and having it on the framebuffer.

You might need to restore the target-type line (bw calculation fails) and/or disable PAC (doesn't seem to like null pointers) to avoid a few issues.
Might also work without the changed T8030_PANIC_BASE value, but also might not.

target-type line:
hw/arm/t8030.c: assert(set_dtb_prop(tms->device_tree, "target-type", 4, "sim")); // TODO: implement PMP

disable/commenting PAC, all roads lead to rome, so many ways to do that in qemu:
target/arm/helper.c: //DP_TBFLAG_A64(flags, PAUTH_ACTIVE, 1);

[1]: https://gist.githubusercontent.com/bazad/1faef1a6fe396b820a43170b43e38be1/raw/e05ea511bb048941aaf234680e1f35e7589ef1e2/devicetree-iPhone12,3-17C54.txt
[2]: https://9to5mac.com/2023/02/07/iphone-display-list/